### PR TITLE
Refactor core modules with shared models and registry

### DIFF
--- a/depclass/cli.py
+++ b/depclass/cli.py
@@ -8,10 +8,10 @@ import yaml
 from depclass.rich_utils.ui_helpers import get_console
 
 from depclass.db.vulnerability import VulnerabilityCache
-from depclass.extract import extract_dependencies
+from depclass.extract import extract
 from depclass.risk import score_packages
 from depclass.risk_model import load_model
-from depclass.sbom import generate_sbom, read_json_file
+from depclass.sbom import generate, read_json_file
 from depclass.validate import validate
 
 # Initialize Typer app
@@ -36,7 +36,8 @@ def main(
     config_path: str = typer.Option("config.yaml", "-c", "--config", help="Path to config YAML"),
     output: Optional[str] = typer.Option(None, "-o", "--output", help="Output file override"),
     skip_sbom: bool = typer.Option(False, "-sb", "--skip-sbom", help="Skip the SBOM report generation"),
-    ignore_conflicts: bool = typer.Option(False, "--ignore-conflicts", help="Continue analysis even when dependency conflicts are detected")
+    ignore_conflicts: bool = typer.Option(False, "--ignore-conflicts", help="Continue analysis even when dependency conflicts are detected"),
+    ecosystem: str = typer.Option("python", "--ecosystem", help="Target dependency ecosystem")
 ):
     """Run ZSBOM security analysis and generate Software Bill of Materials."""
 
@@ -54,7 +55,7 @@ def main(
         cache = VulnerabilityCache(config['caching']['path'])
 
     # Extract dependencies using enhanced parser with transitive analysis
-    dependencies = extract_dependencies(config=config, cache=cache)
+    dependencies = extract(config=config, cache=cache, ecosystem=ecosystem)
     
     # Extract the dependencies dict from the new transitive analysis format
     dependency_data = dependencies.get("dependencies", dependencies)
@@ -138,7 +139,7 @@ def main(
         if cve_data:
             # Use resolution details from transitive analysis for complete dependency coverage
             sbom_dependencies = transitive_data.get("resolution_details", dependency_data)
-            generate_sbom(sbom_dependencies, cve_data, config)
+            generate(sbom_dependencies, cve_data, config)
 
 if __name__ == "__main__":
     app()

--- a/depclass/models.py
+++ b/depclass/models.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class RiskDimension(str, Enum):
+    """Enumeration of supported risk scoring dimensions."""
+    DECLARED_VS_INSTALLED = "declared_vs_installed"
+    KNOWN_CVES = "known_cves"
+    CWE_COVERAGE = "cwe_coverage"
+    PACKAGE_ABANDONMENT = "package_abandonment"
+    TYPOSQUAT_HEURISTICS = "typosquat_heuristics"
+
+
+@dataclass
+class PackageRef:
+    """Reference to a package being analyzed."""
+    name: str
+    installed_version: str
+    declared_version: Optional[str] = None
+    dependency_type: Optional[str] = None

--- a/depclass/risk.py
+++ b/depclass/risk.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .risk_model import RiskModel
 from .risk_calculator import WeightedRiskCalculator
+from .models import PackageRef
 
 
 def parse_declared_versions(dependencies: Dict[str, Any]) -> Dict[str, str]:
@@ -160,10 +161,9 @@ def compute_package_score(
     
     # Calculate comprehensive score using the new framework
     # Note: repo_path is no longer used - repository discovery is now handled automatically
+    pkg_ref = PackageRef(name=package, installed_version=installed_version, declared_version=declared_version)
     result = calculator.calculate_score(
-        package=package,
-        installed_version=installed_version,
-        declared_version=declared_version,
+        package=pkg_ref,
         cve_list=cve_list,
         typosquatting_whitelist=typosquatting_whitelist,
     )
@@ -297,11 +297,9 @@ def score_packages(
         # Get CVEs
         cves = _package_cve_issues(pkg, cve_data)
         
-        # Calculate score with enhanced package specification data
+        pkg_ref = PackageRef(name=pkg, installed_version=installed_version, declared_version=primary_declared_ver)
         detailed_score = calculator.calculate_score(
-            package=pkg,
-            installed_version=installed_version,
-            declared_version=primary_declared_ver,
+            package=pkg_ref,
             cve_list=cves,
             typosquatting_whitelist=typosquatting_whitelist,
             # Pass enhanced data for new declared vs installed analysis

--- a/depclass/risk_calculator.py
+++ b/depclass/risk_calculator.py
@@ -1,6 +1,6 @@
 """Weighted Risk Calculator for ZSBOM risk assessment."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from .dimension_scorers import (
     DeclaredVsInstalledScorer,
@@ -8,156 +8,109 @@ from .dimension_scorers import (
     CWECoverageScorer,
     PackageAbandonmentScorer,
     TyposquatHeuristicsScorer,
+    DimensionScorer,
 )
+from .models import PackageRef, RiskDimension
 from .risk_model import RiskModel
+
+# Pluggable scorer registry
+SCORER_REGISTRY: Dict[RiskDimension, Type[DimensionScorer]] = {}
+
+
+def register_scorer(dimension: RiskDimension, scorer_cls: Type[DimensionScorer]) -> None:
+    """Register a scorer implementation for a risk dimension."""
+    SCORER_REGISTRY[dimension] = scorer_cls
+
+
+# Register default scorers
+register_scorer(RiskDimension.DECLARED_VS_INSTALLED, DeclaredVsInstalledScorer)
+register_scorer(RiskDimension.KNOWN_CVES, KnownCVEsScorer)
+register_scorer(RiskDimension.CWE_COVERAGE, CWECoverageScorer)
+register_scorer(RiskDimension.PACKAGE_ABANDONMENT, PackageAbandonmentScorer)
+register_scorer(RiskDimension.TYPOSQUAT_HEURISTICS, TyposquatHeuristicsScorer)
 
 
 class WeightedRiskCalculator:
-    """Calculates weighted risk scores using the ZSBOM Risk Scoring Framework v1.0.
-    
-    Formula: Weighted Score = (Dimension Score × Weight Percentage)
-    Final Score: Sum of all weighted scores (0-100 scale)
-    """
+    """Calculates weighted risk scores using the ZSBOM Risk Scoring Framework v1.0."""
 
-    def __init__(self, model: Optional[RiskModel] = None):
-        """Initialize the risk calculator.
-        
-        Args:
-            model: RiskModel with weights and thresholds
-        """
+    def __init__(
+        self,
+        model: Optional[RiskModel] = None,
+        scorer_registry: Optional[Dict[RiskDimension, Type[DimensionScorer]]] = None,
+    ):
         self.model = model or RiskModel()
-        
-        # Initialize dimension scorers
-        self.scorers = {
-            "declared_vs_installed": DeclaredVsInstalledScorer(),
-            "known_cves": KnownCVEsScorer(),
-            "cwe_coverage": CWECoverageScorer(),
-            "package_abandonment": PackageAbandonmentScorer(),
-            "typosquat_heuristics": TyposquatHeuristicsScorer(),
-        }
+        registry = scorer_registry or SCORER_REGISTRY
+        self.scorers = {dim: cls() for dim, cls in registry.items()}
 
     def calculate_score(
         self,
-        package: str,
-        installed_version: str,
+        package: PackageRef | str,
+        installed_version: str | None = None,
         declared_version: Optional[str] = None,
         cve_list: Optional[List[Dict[str, Any]]] = None,
         typosquatting_whitelist: Optional[List[str]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Calculate comprehensive risk score for a package.
-        
-        Args:
-            package: Package name
-            installed_version: Currently installed version
-            declared_version: Version declared in requirements
-            cve_list: List of CVE dictionaries
-            typosquatting_whitelist: List of known safe packages
-            **kwargs: Additional arguments
-            
-        Returns:
-            Dictionary containing scores, risk level, and detailed breakdown
-        """
-        # Calculate individual dimension scores (0-10 scale)
-        dimension_scores = {}
-        dimension_details = {}
-        
-        # Declared vs Installed dimension
-        dimension_scores["declared_vs_installed"] = self.scorers["declared_vs_installed"].score(
-            package, installed_version, declared_version, **kwargs
-        )
-        dimension_details["declared_vs_installed"] = self.scorers["declared_vs_installed"].get_details(
-            package, installed_version, declared_version, **kwargs
-        )
-        
-        # Known CVEs dimension
-        dimension_scores["known_cves"] = self.scorers["known_cves"].score(
-            package, installed_version, declared_version, cve_list=cve_list, **kwargs
-        )
-        dimension_details["known_cves"] = self.scorers["known_cves"].get_details(
-            package, installed_version, declared_version, cve_list=cve_list, **kwargs
-        )
-        
-        # CWE Coverage dimension
-        dimension_scores["cwe_coverage"] = self.scorers["cwe_coverage"].score(
-            package, installed_version, declared_version, cve_list=cve_list, **kwargs
-        )
-        dimension_details["cwe_coverage"] = self.scorers["cwe_coverage"].get_details(
-            package, installed_version, declared_version, cve_list=cve_list, **kwargs
-        )
-        
-        # Package Abandonment dimension
-        dimension_scores["package_abandonment"] = self.scorers["package_abandonment"].score(
-            package, installed_version, declared_version, **kwargs
-        )
-        dimension_details["package_abandonment"] = self.scorers["package_abandonment"].get_details(
-            package, installed_version, declared_version, **kwargs
-        )
-        
-        # Typosquat Heuristics dimension
-        dimension_scores["typosquat_heuristics"] = self.scorers["typosquat_heuristics"].score(
-            package, installed_version, declared_version, typosquatting_whitelist=typosquatting_whitelist, **kwargs
-        )
-        dimension_details["typosquat_heuristics"] = self.scorers["typosquat_heuristics"].get_details(
-            package, installed_version, declared_version, typosquatting_whitelist=typosquatting_whitelist, **kwargs
-        )
-        
-        # Apply weights to get weighted contributions
+        """Calculate comprehensive risk score for a package."""
+        if isinstance(package, PackageRef):
+            pkg = package
+        else:
+            pkg = PackageRef(name=package, installed_version=installed_version or "", declared_version=declared_version)
+
+        dimension_scores: Dict[RiskDimension, float] = {}
+        dimension_details: Dict[RiskDimension, Dict[str, Any]] = {}
+
+        for dim, scorer in self.scorers.items():
+            dimension_scores[dim] = scorer.score(
+                pkg.name,
+                pkg.installed_version,
+                pkg.declared_version,
+                cve_list=cve_list,
+                typosquatting_whitelist=typosquatting_whitelist,
+                **kwargs,
+            )
+            dimension_details[dim] = scorer.get_details(
+                pkg.name,
+                pkg.installed_version,
+                pkg.declared_version,
+                cve_list=cve_list,
+                typosquatting_whitelist=typosquatting_whitelist,
+                **kwargs,
+            )
+
         weighted_contributions = self._apply_weights(dimension_scores)
-        
-        # Calculate final score (0-100 scale)
         final_score = sum(weighted_contributions.values())
-        
-        # Determine risk level
         risk_level = self._determine_risk_level(final_score)
-        
+
         return {
-            "package": package,
-            "installed_version": installed_version,
-            "declared_version": declared_version,
+            "package": pkg.name,
+            "installed_version": pkg.installed_version,
+            "declared_version": pkg.declared_version,
             "final_score": round(final_score, 2),
             "risk_level": risk_level,
-            "dimension_scores": {k: round(v, 2) for k, v in dimension_scores.items()},
-            "weighted_contributions": {k: round(v, 2) for k, v in weighted_contributions.items()},
-            "dimension_details": dimension_details,
+            "dimension_scores": {k.value: round(v, 2) for k, v in dimension_scores.items()},
+            "weighted_contributions": {k.value: round(v, 2) for k, v in weighted_contributions.items()},
+            "dimension_details": {k.value: v for k, v in dimension_details.items()},
             "calculation_metadata": {
-                "weights_used": self.model.get_weights_dict(),
+                "weights_used": {k.value: v for k, v in self.model.get_weights_dict().items()},
                 "thresholds_used": self.model.get_thresholds_dict(),
                 "framework_version": "1.0",
             },
         }
 
-    def _apply_weights(self, dimension_scores: Dict[str, float]) -> Dict[str, float]:
-        """Apply percentage weights to dimension scores.
-        
-        Formula: Weighted Score = (Dimension Score × Weight Percentage)
-        
-        Args:
-            dimension_scores: Dictionary of dimension scores (0-10 scale)
-            
-        Returns:
-            Dictionary of weighted contributions (0-100 scale)
-        """
+    def _apply_weights(
+        self, dimension_scores: Dict[RiskDimension, float]
+    ) -> Dict[RiskDimension, float]:
+        """Apply percentage weights to dimension scores."""
         weights = self.model.get_weights_dict()
-        weighted_contributions = {}
-        
+        weighted_contributions: Dict[RiskDimension, float] = {}
         for dimension, score in dimension_scores.items():
             weight_percentage = weights.get(dimension, 0) / 100.0
-            # Framework formula: score (0-10) * weight_percentage * 10 to get 0-100 scale
             weighted_contribution = score * weight_percentage * 10
             weighted_contributions[dimension] = weighted_contribution
-        
         return weighted_contributions
 
     def _determine_risk_level(self, final_score: float) -> str:
-        """Determine risk level based on final score.
-        
-        Args:
-            final_score: Final risk score (0-100 scale)
-            
-        Returns:
-            Risk level string ('low', 'medium', or 'high')
-        """
         if final_score >= self.model.low_risk_threshold:
             return "low"
         elif final_score >= self.model.medium_risk_threshold:
@@ -166,52 +119,27 @@ class WeightedRiskCalculator:
             return "high"
 
     def validate_model(self) -> List[str]:
-        """Validate the risk model configuration.
-        
-        Returns:
-            List of validation error messages (empty if valid)
-        """
         errors = []
-        
-        # Check that weights sum to 100%
         weights = self.model.get_weights_dict()
         total_weight = sum(weights.values())
-        if abs(total_weight - 100.0) > 0.01:  # Allow small floating point errors
+        if abs(total_weight - 100.0) > 0.01:
             errors.append(f"Weights must sum to 100%, got {total_weight}%")
-        
-        # Check that all required dimensions have weights
-        required_dimensions = {
-            "declared_vs_installed",
-            "known_cves",
-            "cwe_coverage",
-            "package_abandonment",
-            "typosquat_heuristics",
-        }
-        
+        required_dimensions = set(SCORER_REGISTRY.keys())
         for dimension in required_dimensions:
             if dimension not in weights:
-                errors.append(f"Missing weight for dimension: {dimension}")
+                errors.append(f"Missing weight for dimension: {dimension.value}")
             elif weights[dimension] < 0:
-                errors.append(f"Weight for {dimension} cannot be negative")
-        
-        # Check threshold values
+                errors.append(f"Weight for {dimension.value} cannot be negative")
         if self.model.low_risk_threshold <= self.model.medium_risk_threshold:
             errors.append("Low risk threshold must be higher than medium risk threshold")
-        
         if self.model.medium_risk_threshold < 0 or self.model.low_risk_threshold > 100:
             errors.append("Risk thresholds must be between 0 and 100")
-        
         return errors
 
     def get_framework_info(self) -> Dict[str, Any]:
-        """Get information about the risk scoring framework.
-        
-        Returns:
-            Dictionary containing framework information
-        """
         return {
             "framework_version": "1.0",
-            "dimensions": list(self.scorers.keys()),
+            "dimensions": [d.value for d in self.scorers.keys()],
             "score_range": "0-100",
             "dimension_score_range": "0-10",
             "risk_levels": ["low", "medium", "high"],
@@ -220,5 +148,5 @@ class WeightedRiskCalculator:
                 "medium": f"{self.model.medium_risk_threshold}-{self.model.low_risk_threshold-1}",
                 "high": f"0-{self.model.medium_risk_threshold-1}",
             },
-            "weights": self.model.get_weights_dict(),
+            "weights": {k.value: v for k, v in self.model.get_weights_dict().items()},
         }

--- a/depclass/risk_model.py
+++ b/depclass/risk_model.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from .models import RiskDimension
+
 
 @dataclass
 class RiskModel:
@@ -17,14 +19,14 @@ class RiskModel:
     low_risk_threshold: float = 80.0    # 80-100 = Low Risk
     medium_risk_threshold: float = 50.0 # 50-79 = Medium Risk (0-49 = High Risk)
 
-    def get_weights_dict(self) -> Dict[str, float]:
-        """Get weights as a dictionary for easy access."""
+    def get_weights_dict(self) -> Dict[RiskDimension, float]:
+        """Get weights keyed by RiskDimension."""
         return {
-            "declared_vs_installed": self.weight_declared_vs_installed,
-            "known_cves": self.weight_known_cves,
-            "cwe_coverage": self.weight_cwe_coverage,
-            "package_abandonment": self.weight_package_abandonment,
-            "typosquat_heuristics": self.weight_typosquat_heuristics,
+            RiskDimension.DECLARED_VS_INSTALLED: self.weight_declared_vs_installed,
+            RiskDimension.KNOWN_CVES: self.weight_known_cves,
+            RiskDimension.CWE_COVERAGE: self.weight_cwe_coverage,
+            RiskDimension.PACKAGE_ABANDONMENT: self.weight_package_abandonment,
+            RiskDimension.TYPOSQUAT_HEURISTICS: self.weight_typosquat_heuristics,
         }
 
     def get_thresholds_dict(self) -> Dict[str, float]:

--- a/depclass/sbom.py
+++ b/depclass/sbom.py
@@ -31,7 +31,7 @@ SEVERITY_MAP = {
 
 
 
-def generate_sbom(dependencies: dict, cve_data: dict, config: dict):
+def generate(dependencies: dict, cve_data: dict, config: dict):
     bom = Bom()
     bom.metadata.tools.components.add(cdx_lib_component())
     component_map = {}
@@ -58,6 +58,10 @@ def generate_sbom(dependencies: dict, cve_data: dict, config: dict):
         f.write(sbom.output_as_string())
     
     print(f"SBOM report exported to: {output_path}")
+
+
+# Backwards compatibility
+generate_sbom = generate
 
 def validate_json_format(sbom):
     serialized_json = sbom.output_as_string(indent=2)
@@ -218,3 +222,4 @@ def read_json_file(file_path: str):
 #    outputter = get_instance(bom, output_format='json')
 #    with open("sbom.json", "w") as f:
 #        f.write(outputter.output_as_string())
+

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from packaging.specifiers import SpecifierSet
 
-from depclass.extract import DependencyFileParser, extract_dependencies
+from depclass.extract import DependencyFileParser, extract
 
 
 class TestDependencyFileParser:
@@ -285,7 +285,7 @@ class TestExtractDependenciesFunction:
             req_file = Path(temp_dir) / "requirements.txt"
             req_file.write_text("requests==2.28.0\nnumpy>=1.21.0")
             
-            result = extract_dependencies(temp_dir)
+            result = extract(project_path=temp_dir)
             
             # New format includes both dependencies and transitive_analysis
             assert "dependencies" in result
@@ -300,7 +300,7 @@ class TestExtractDependenciesFunction:
     def test_extract_dependencies_current_directory(self):
         """Test extract_dependencies with default current directory."""
         # This should run without errors and return runtime packages
-        result = extract_dependencies()
+        result = extract()
         
         assert "dependencies" in result
         assert "transitive_analysis" in result
@@ -321,7 +321,7 @@ class TestExtractDependenciesFunction:
 dependencies = ["requests>=2.28.0", "flask>=2.0.0"]
             """)
             
-            result = extract_dependencies(temp_dir)
+            result = extract(project_path=temp_dir)
             
             # New format includes both dependencies and transitive_analysis
             assert "dependencies" in result

--- a/tests/test_framework_compliance.py
+++ b/tests/test_framework_compliance.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pytest
 from depclass.risk_calculator import WeightedRiskCalculator
 from depclass.risk_model import RiskModel
+from depclass.models import RiskDimension
 
 
 class TestFrameworkCompliance:
@@ -20,11 +21,11 @@ class TestFrameworkCompliance:
         
         # Simulate the framework example scores
         dimension_scores = {
-            'declared_vs_installed': 8.0,
-            'known_cves': 10.0,
-            'cwe_coverage': 10.0,
-            'package_abandonment': 2.0,
-            'typosquat_heuristics': 10.0
+            RiskDimension.DECLARED_VS_INSTALLED: 8.0,
+            RiskDimension.KNOWN_CVES: 10.0,
+            RiskDimension.CWE_COVERAGE: 10.0,
+            RiskDimension.PACKAGE_ABANDONMENT: 2.0,
+            RiskDimension.TYPOSQUAT_HEURISTICS: 10.0,
         }
         
         # Test individual weighted contributions
@@ -32,11 +33,11 @@ class TestFrameworkCompliance:
         
         # Framework expected values
         expected_contributions = {
-            'declared_vs_installed': 12.0,  # 8 × 15% × 10
-            'known_cves': 30.0,            # 10 × 30% × 10
-            'cwe_coverage': 20.0,          # 10 × 20% × 10
-            'package_abandonment': 4.0,    # 2 × 20% × 10
-            'typosquat_heuristics': 15.0   # 10 × 15% × 10
+            RiskDimension.DECLARED_VS_INSTALLED: 12.0,
+            RiskDimension.KNOWN_CVES: 30.0,
+            RiskDimension.CWE_COVERAGE: 20.0,
+            RiskDimension.PACKAGE_ABANDONMENT: 4.0,
+            RiskDimension.TYPOSQUAT_HEURISTICS: 15.0,
         }
         
         for dimension, expected in expected_contributions.items():


### PR DESCRIPTION
## Summary
- Add `PackageRef` dataclass and `RiskDimension` enum as shared models
- Introduce extractor registry and ecosystem-aware `extract` API
- Implement pluggable scorer registry with `PackageRef` support and CLI `--ecosystem` flag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyyaml')*

------
https://chatgpt.com/codex/tasks/task_e_689774d71f9c8327ad4d7e0d2161c9b2